### PR TITLE
Fix hook command for bare repos

### DIFF
--- a/_posts/2016-10-28-deploy.md
+++ b/_posts/2016-10-28-deploy.md
@@ -52,7 +52,7 @@ How can you use this feature? There's a hook called `post-receive`, which Git wi
 It's not actually quite *that* simple, but that's the basic process. To create the hook, run the following commands on your server:
 
 ```shell
-$ cd <REPOSITORY NAME>.git/.git/hooks
+$ cd <REPOSITORY NAME>.git/hooks
 $ touch post-receive
 $ chmod +x post-receive
 $ nano post-receive


### PR DESCRIPTION
Hi Noah, I just followed your Jekyll deployment tutorial, thanks for that!

I think there's a tiny mistake in setting up the hook. Since it's a bare repo, the `hook` folder is created in the root folder, not under the `.git` folder.